### PR TITLE
patch conda

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -22,36 +22,40 @@ RUN curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/downloa
     chown ${NB_USER}:staff -R ${CONDA_ENV}
 
 # podman doesn't not understand group permissions
-RUN chown ${NB_USER}:staff -R ${R_HOME}/site-library
+# RUN chown ${NB_USER}:staff -R ${R_HOME}/site-library
 
-# some teaching preferences
+# some teaching preferences; might replace with gh-creds
 RUN git config --system pull.rebase false && \
     git config --system credential.helper 'cache --timeout=36000'
 
-## codeserver
+## codeserver; Add VSCode button
 RUN curl -fsSL https://code-server.dev/install.sh | sh && rm -rf .cache
 
+## Install the R packages into site library
+COPY install.R install.R
+RUN Rscript install.R && rm install.R
 
 ## Openscapes-specific configs
 USER rstudio
 WORKDIR /home/rstudio
+# make bash the user default
 RUN usermod -s /bin/bash rstudio
 
-# install into the default environment
+# install into the default venv environment
 COPY nasa-requirements.txt requirements.txt
 RUN python -m pip install -r requirements.txt && rm requirements.txt
-COPY install.R install.R
-RUN Rscript install.R && rm install.R
 
 # Create a conda-based env and install into it without using conda init/conda activate
 # (this yaml file doesn't include everything from pangeo, consider a different one...)
-ENV MY_ENV=${CONDA_ENV}/envs/openscapes
+# pangeo uses the name 'notebook'
+ENV ENV_NAME=notebook
+ENV MY_ENV=${CONDA_ENV}/envs/${ENV_NAME}
 RUN wget https://github.com/NASA-Openscapes/corn/raw/main/ci/environment.yml && \
     conda env create -p ${MY_ENV} -f environment.yml
 
-# This won't be the default enviornment but we register it
+# This won't be the default environment but we register it
 RUN ${MY_ENV}/bin/python -m pip install ipykernel && \
-    ${MY_ENV}/bin/python -m ipykernel install --prefix /opt/venv --name=openscapes
+    ${MY_ENV}/bin/python -m ipykernel install --prefix /opt/venv --name=${ENV_NAME}
 
 
 

--- a/.devcontainer/conda.Dockerfile
+++ b/.devcontainer/conda.Dockerfile
@@ -3,17 +3,15 @@ FROM ghcr.io/rocker-org/devcontainer/tidyverse:4.3
 
 # latest version of geospatial libs
 RUN /rocker_scripts/experimental/install_dev_osgeo.sh && rm -rf /build_*
+# install vim for convenience
 RUN apt-get update -qq && apt-get -y install vim
-
-# podman doesn't understand group permissions
-RUN chown rstudio:staff ${R_HOME}/site-library
 
 # some teaching preferences
 RUN git config --system pull.rebase false && \
     git config --system credential.helper 'cache --timeout=36000'
 
-# codeserver
-RUN curl -fsSL https://code-server.dev/install.sh | sh
+# codeserver; Adds the VSCode button
+RUN curl -fsSL https://code-server.dev/install.sh | sh && rm -rf .cache
 
 # Set up conda
 ENV NB_USER=rstudio
@@ -22,9 +20,14 @@ ENV PATH=${CONDA_ENV}/bin:${PATH}
 RUN curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" && \
     bash Miniforge3-$(uname)-$(uname -m).sh -b -p ${CONDA_ENV} && \
     chown ${NB_USER}:staff -R ${CONDA_ENV} && \
-    rm Miniforge3*.sh *.deb
+    rm -f Miniforge3*.sh *.deb
 
+# Tell RStudio how to find Python
 RUN echo "PATH=${PATH}" >>"${R_HOME}/etc/Renviron.site"
+
+# install R packages into the site library
+COPY install.R install.R
+RUN Rscript install.R && rm install.R
 
 # Initialize conda by default for all users:
 RUN conda init --system
@@ -32,11 +35,8 @@ RUN conda init --system
 # Standard user setup here
 USER ${NB_USER} 
 WORKDIR /home/${NB_USER}
+# make bash default shell
 RUN usermod -s /bin/bash ${NB_USER} 
-
-# install into the default environment
-COPY install.R install.R
-RUN Rscript install.R && rm install.R
 
 COPY environment.yml environment.yml
 RUN conda env update -f environment.yml && conda clean --all

--- a/.devcontainer/conda.Dockerfile
+++ b/.devcontainer/conda.Dockerfile
@@ -4,9 +4,10 @@ FROM ghcr.io/rocker-org/devcontainer/tidyverse:4.3
 ## Set the default shell
 ENV SHELL=/bin/bash
 
-# latest version of geospatial libs
-RUN /rocker_scripts/experimental/install_dev_osgeo.sh && rm -rf /build_*
+# latest version of geospatial libs -- big! 
+# RUN /rocker_scripts/experimental/install_dev_osgeo.sh && rm -rf /build_*
 # install vim for convenience
+
 RUN apt-get update -qq && apt-get -y install vim
 
 # some teaching preferences
@@ -16,8 +17,14 @@ RUN git config --system pull.rebase false && \
 # codeserver; Adds the VSCode button
 RUN curl -fsSL https://code-server.dev/install.sh | sh && rm -rf .cache
 
+# Rename the rstudio user as jovyan
+RUN usermod -l jovyan rstudio && \
+    usermod -d /home/jovyan -m jovyan && \
+    groupmod -n jovyan rstudio
+
+
 # Set up conda
-ENV NB_USER=rstudio
+ENV NB_USER=jovyan
 ENV CONDA_ENV=/opt/miniforge3
 ENV PATH=${CONDA_ENV}/bin:${PATH}
 RUN curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" && \
@@ -40,6 +47,10 @@ USER ${NB_USER}
 WORKDIR /home/${NB_USER}
 # make bash default shell
 RUN usermod -s /bin/bash ${NB_USER} 
+
+
+ENV NOTEBOOK_ENV=${CONDA_ENV}/envs/openscapes
+ENV PATH=${NOTEBOOK_ENV}/bin:${PATH}
 
 COPY environment.yml environment.yml
 RUN conda env update -f environment.yml && conda clean --all

--- a/.devcontainer/conda.Dockerfile
+++ b/.devcontainer/conda.Dockerfile
@@ -1,6 +1,9 @@
 # devcontainer-focused Rocker
 FROM ghcr.io/rocker-org/devcontainer/tidyverse:4.3
 
+## Set the default shell
+ENV SHELL=/bin/bash
+
 # latest version of geospatial libs
 RUN /rocker_scripts/experimental/install_dev_osgeo.sh && rm -rf /build_*
 RUN apt-get update -qq && apt-get -y install vim

--- a/.devcontainer/conda.Dockerfile
+++ b/.devcontainer/conda.Dockerfile
@@ -32,6 +32,9 @@ RUN curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/downloa
     chown ${NB_USER}:staff -R ${CONDA_ENV} && \
     rm -f Miniforge3*.sh *.deb
 
+ENV NOTEBOOK_ENV=${CONDA_ENV}/envs/openscapes
+ENV PATH=${NOTEBOOK_ENV}/bin:${PATH}
+
 # Tell RStudio how to find Python
 RUN echo "PATH=${PATH}" >>"${R_HOME}/etc/Renviron.site"
 
@@ -39,7 +42,6 @@ RUN echo "PATH=${PATH}" >>"${R_HOME}/etc/Renviron.site"
 COPY install.R install.R
 RUN Rscript install.R && rm install.R
 
-# Initialize conda by default for all users:
 RUN conda init --system
 
 # Standard user setup here
@@ -47,10 +49,6 @@ USER ${NB_USER}
 WORKDIR /home/${NB_USER}
 # make bash default shell
 RUN usermod -s /bin/bash ${NB_USER} 
-
-
-ENV NOTEBOOK_ENV=${CONDA_ENV}/envs/openscapes
-ENV PATH=${NOTEBOOK_ENV}/bin:${PATH}
 
 COPY environment.yml environment.yml
 RUN conda env update -f environment.yml && conda clean --all

--- a/.devcontainer/install.R
+++ b/.devcontainer/install.R
@@ -4,9 +4,9 @@
 # We could use renv.lock approach here instead, but will force re-creation of environment from scratch
 # Does not provide a good way to ensure that sf/terra/gdalcubes are installed from source while other packages can be binary
 # Likewise, pak insists on installing old gdal from apt instead of respecting system library source builds
-# install.packages("pak")
-install.packages(c("rstac", "spData", "earthdatalogin", "quarto", "aws.s3", "tmap", "reticulate"))
-remotes::install_github('r-tmap/tmap', upgrade=FALSE)
+install.packages("pak")
+pak::pkg_install(c("rstac", "spData", "earthdatalogin", "quarto", "aws.s3", "tmap", "reticulate"))
+pak::pkg_install('r-tmap/tmap')
 
 #pak::pkg_install("httpgd")
 #pak::pkg_install(c("IRkernel", "languageserver"))

--- a/.devcontainer/venv.Dockerfile
+++ b/.devcontainer/venv.Dockerfile
@@ -1,6 +1,9 @@
 ## devcontainer-focused Rocker
 FROM ghcr.io/rocker-org/devcontainer/tidyverse:4.3
 
+## Set the default shell
+ENV SHELL=/bin/bash
+
 ## latest version of geospatial libs
 RUN /rocker_scripts/experimental/install_dev_osgeo.sh && rm -rf build_*
 RUN apt-get update -qq && apt-get -y install vim

--- a/.devcontainer/venv.Dockerfile
+++ b/.devcontainer/venv.Dockerfile
@@ -11,6 +11,7 @@ RUN /rocker_scripts/experimental/install_dev_osgeo.sh && rm -rf build_*
 RUN apt-get update -qq && apt-get -y install vim
 
 # standard python/jupyter setup
+# install python that is with the ubuntu install
 ENV NB_USER=rstudio
 ENV VIRTUAL_ENV=/opt/venv
 ENV PATH=${VIRTUAL_ENV}/bin:${PATH}

--- a/.devcontainer/venv.Dockerfile
+++ b/.devcontainer/venv.Dockerfile
@@ -6,6 +6,8 @@ ENV SHELL=/bin/bash
 
 ## latest version of geospatial libs
 RUN /rocker_scripts/experimental/install_dev_osgeo.sh && rm -rf build_*
+
+## install vim
 RUN apt-get update -qq && apt-get -y install vim
 
 # standard python/jupyter setup
@@ -15,10 +17,6 @@ ENV PATH=${VIRTUAL_ENV}/bin:${PATH}
 RUN /rocker_scripts/install_python.sh && \
   chown ${NB_USER}:staff -R ${VIRTUAL_ENV}
 
-# podman doesn't not understand group permissions
-# RUN chown ${NB_USER}:staff -R ${R_HOME}/site-library
-RUN chown ${NB_USER}:staff ${R_HOME}/site-library
-
 # some teaching preferences
 RUN git config --system pull.rebase false && \
     git config --system credential.helper 'cache --timeout=36000'
@@ -26,14 +24,16 @@ RUN git config --system pull.rebase false && \
 ## codeserver
 RUN curl -fsSL https://code-server.dev/install.sh | sh && rm -rf .cache
 
+## Install R packages into the site library
+COPY install.R install.R
+RUN Rscript install.R && rm install.R
+
 ## Openscapes-specific configs
 USER rstudio
 WORKDIR /home/rstudio
 RUN usermod -s /bin/bash rstudio
 
-# install into the default environment
+# install into the default venv environment
 COPY nasa-requirements.txt requirements.txt
 RUN python -m pip install --no-cache-dir -r requirements.txt && rm requirements.txt
-COPY install.R install.R
-RUN Rscript install.R && rm install.R
 

--- a/.devcontainer/welcome.sh
+++ b/.devcontainer/welcome.sh
@@ -1,7 +1,8 @@
+# Need to add this so that RStudio knows the project it is in
 mkdir -p ~/.local/share/rstudio/projects_settings
+
 export RPROJ"=$(ls ${CODESPACE_VSCODE_FOLDER}/*.Rproj)"
 echo ${RPROJ} > ~/.local/share/rstudio/projects_settings/last-project-path
-
 
 # Construct the message
 message="## [Open in RStudio](https://$CODESPACE_NAME-8787.app.github.dev)
@@ -13,4 +14,8 @@ echo "
 
 🌐 Open the RStudio editor here: https://$CODESPACE_NAME-8787.app.github.dev
    - (This may take a few seconds to load, retry if necessary)
+
+🌐 Open the JupyterLab editor here: https://$CODESPACE_NAME.app.github.dev?editor=jupyter
+   - (This may take a few seconds to load, retry if necessary)
+
 "


### PR DESCRIPTION
@eeholmes This should fix a few issues we had with Conda.  

- default user in now jovyan everywhere, no more user called `rstudio` 

- conda seems to insist that it has (base) environment and that any other environment created by an environment.yml needs a name, it doesn't seem to want to just 'extend' base.  This means that since jupyterhub-singleuser was installed in from the environment.yml, we need to make sure said environment is also on the PATH so that jupyterhub server can launch.  

- I've dropped the gdal source install to save about 3GB, and switched to pak install which will grab the necessary system libraries for R packages.  

I think this needs a little more testing still.  